### PR TITLE
Correct check of empty git editor config

### DIFF
--- a/git-subline-merge
+++ b/git-subline-merge
@@ -554,7 +554,7 @@ def manual_merge_hunk(hunk):
 
     # imitate the process that Git uses to determine which editor to use
     editor = os.getenv('GIT_EDITOR')
-    if editor is None: editor = os.popen('git config core.editor').read().rstrip('\n')
+    if editor is None: editor = os.popen('git config core.editor').read().rstrip('\n') or None
     if editor is None: editor = os.getenv('VISUAL')
     if editor is None: editor = os.getenv('EDITOR')
     if editor is None: editor = 'vi'


### PR DESCRIPTION
The os.popen.read() dance will return an empty string in the case
that no editor is set, not None like the other entries in the
resolution order.

If the return evalutes False, including the empty string, coerce
that to NoneType for consistency with the other checks.

Without this, and with no $GIT_EDITOR set, the script tries to
execute the empty string which, on Windows at least, is a
PermissionError.