### PR TITLE
Quote a regex string

### DIFF
--- a/git-hires-merge
+++ b/git-hires-merge
@@ -336,11 +336,11 @@ def format_changed_hunk(h1, h2, display, color_added, color_deleted):
     # keep track of where the linebreaks are in terms of segment index
     splA, splB, lcA, lcB = [], [], [0], [0]
     for ln in h1:
-        segments = re.split('(\W)', ln)
+        segments = re.split(r'(\W)', ln)
         splA += segments
         lcA.append(lcA[-1] + len(segments))
     for ln in h2:
-        segments = re.split('(\W)', ln)
+        segments = re.split(r'(\W)', ln)
         splB += segments
         lcB.append(lcB[-1] + len(segments))
     lcA.pop(0)


### PR DESCRIPTION
Running git-hires-merge yields:

```
git-hires-merge:339: SyntaxWarning: invalid escape sequence '\W'
  segments = re.split('(\W)', ln)
git-hires-merge:343: SyntaxWarning: invalid escape sequence '\W'
  segments = re.split('(\W)', ln)
```

This patch seems to fix it.